### PR TITLE
[Fix] Response Type not match in ChartCannelsRecent

### DIFF
--- a/supabase/functions/charts/EndPoint/ChartChannels/GetRecentChannels.ts
+++ b/supabase/functions/charts/EndPoint/ChartChannels/GetRecentChannels.ts
@@ -75,8 +75,7 @@ export class ChartChannelsRecent {
               success: {
                 channel_id: headTable.id,
                 channel_name: headTable.name,
-                channel_thumbnail: headTable.thumbnailURLString,
-                sqoop_count: 0
+                channel_thumbnail: headTable.thumbnailURLString
             }, 
             failed: null 
             };


### PR DESCRIPTION
``` swift 
return { 
              success: {
                channel_id: headTable.id,
                channel_name: headTable.name,
                channel_thumbnail: headTable.thumbnailURLString,
                channel_count: 0
            }, 
            failed: null 
            };
```
으로 작성된 오류 수정